### PR TITLE
Bump `infection/infection` from `0.31.0` to `0.31.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "infection/infection": "~0.31.0",
+        "infection/infection": "~0.31.1",
         "mockery/mockery": "~1.6.12",
         "phpunit/phpunit": "~12.3.0",
         "symfony/var-dumper": "~7.3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "743d1fda17d370344fc6992d30678d8e",
+    "content-hash": "307a846361d4597d8db17866ac02788e",
     "packages": [],
     "packages-dev": [
         {
@@ -2603,16 +2603,16 @@
         },
         {
             "name": "infection/infection",
-            "version": "0.31.0",
+            "version": "0.31.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infection/infection.git",
-                "reference": "94ef40f9d469d2d0f20f82081f700b0754ad949a"
+                "reference": "210e22e670cc6c03ee7c20ce34ff63db3a99a6ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/94ef40f9d469d2d0f20f82081f700b0754ad949a",
-                "reference": "94ef40f9d469d2d0f20f82081f700b0754ad949a",
+                "url": "https://api.github.com/repos/infection/infection/zipball/210e22e670cc6c03ee7c20ce34ff63db3a99a6ea",
+                "reference": "210e22e670cc6c03ee7c20ce34ff63db3a99a6ea",
                 "shasum": ""
             },
             "require": {
@@ -2718,7 +2718,7 @@
             ],
             "support": {
                 "issues": "https://github.com/infection/infection/issues",
-                "source": "https://github.com/infection/infection/tree/0.31.0"
+                "source": "https://github.com/infection/infection/tree/0.31.1"
             },
             "funding": [
                 {
@@ -2730,7 +2730,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2025-07-28T16:45:25+00:00"
+            "time": "2025-08-04T09:59:16+00:00"
         },
         {
             "name": "infection/mutator",


### PR DESCRIPTION
Bumps `infection/infection` from `0.31.0` to `0.31.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`