### PR TITLE
Update ghostwriter/coding-standard to version dev-main#ea2be7c

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,9 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^12.3.12",
-        "symfony/var-dumper": "^7.3.3"
+        "mockery/mockery": "~1.6.12",
+        "phpunit/phpunit": "~12.3.12",
+        "symfony/var-dumper": "~7.3.3"
     },
     "prefer-stable": true,
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5a5fcef9fb24f372e34a61c2fd2c3f9",
+    "content-hash": "25a9b2f411c9a2fff1cc80a3643c51d9",
     "packages": [],
     "packages-dev": [
         {
@@ -766,12 +766,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "62def0cbc87cc8cea445ef9bceb42278b8f9d08e"
+                "reference": "ea2be7cf71be411d7350ff61c003867453992ba0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/62def0cbc87cc8cea445ef9bceb42278b8f9d08e",
-                "reference": "62def0cbc87cc8cea445ef9bceb42278b8f9d08e",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/ea2be7cf71be411d7350ff61c003867453992ba0",
+                "reference": "ea2be7cf71be411d7350ff61c003867453992ba0",
                 "shasum": ""
             },
             "require": {
@@ -928,7 +928,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-21T14:31:25+00:00"
+            "time": "2025-09-21T15:43:42+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#62def0c` to `dev-main#ea2be7c`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`