### PR TITLE
Update boundwize/structarmed to version 0.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.1",
+        "boundwize/structarmed": "^0.6.2",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21d71f10aeb0d59c9e5ae35a339ad5f0",
+    "content-hash": "a65be4df3d399bf81df83eacbc459c2b",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.1",
+            "version": "0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "a13d3ef491e707d40e83c20fd8b1f07e9d96cd8f"
+                "reference": "e85dcdf401fd3971f5389893862ab999eead1569"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/a13d3ef491e707d40e83c20fd8b1f07e9d96cd8f",
-                "reference": "a13d3ef491e707d40e83c20fd8b1f07e9d96cd8f",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/e85dcdf401fd3971f5389893862ab999eead1569",
+                "reference": "e85dcdf401fd3971f5389893862ab999eead1569",
                 "shasum": ""
             },
             "require": {
@@ -67,7 +67,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.1"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.2"
             },
             "funding": [
                 {
@@ -75,7 +75,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-15T18:44:44+00:00"
+            "time": "2026-05-16T07:16:18+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -144,16 +144,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "1ad421abff25c39a3e4c261a417db9b3a2e1705d"
+                "reference": "968292530cd54c945f08907d664cfc16c5a4668d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/1ad421abff25c39a3e4c261a417db9b3a2e1705d",
-                "reference": "1ad421abff25c39a3e4c261a417db9b3a2e1705d",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/968292530cd54c945f08907d664cfc16c5a4668d",
+                "reference": "968292530cd54c945f08907d664cfc16c5a4668d",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.6.1",
+                "boundwize/structarmed": "^0.6.2",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -264,7 +264,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-15T23:14:36+00:00"
+            "time": "2026-05-16T11:04:23+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.1` to `0.6.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`